### PR TITLE
refactor: nodes

### DIFF
--- a/sae_eap/attribute.py
+++ b/sae_eap/attribute.py
@@ -6,8 +6,7 @@ from einops import einsum
 
 from sae_eap import utils
 from sae_eap.core.types import ForwardHook, BackwardHook
-from sae_eap.graph import TensorGraph
-from sae_eap.graph.node import SrcNode, DestNode
+from sae_eap.graph import TensorGraph, EdgeName, TensorNode
 from sae_eap.graph.index import TensorNodeIndex
 from sae_eap.cache import (
     CacheDict,
@@ -107,7 +106,7 @@ def compute_model_caches(
 
 
 def compute_node_act_cache(
-    node_index: dict[SrcNode, TensorNodeIndex],
+    node_index: dict[TensorNode, TensorNodeIndex],
     model_act_cache: CacheDict,
 ) -> CacheTensor:
     node_act_cache = init_cache_tensor(
@@ -127,7 +126,7 @@ def compute_node_act_cache(
 
 
 def compute_node_grad_cache(
-    node_index: dict[DestNode, TensorNodeIndex],
+    node_index: dict[TensorNode, TensorNodeIndex],
     model_grad_cache: CacheDict,
 ) -> CacheTensor:
     node_grad_cache = init_cache_tensor(
@@ -178,11 +177,11 @@ def compute_attribution_scores(
     return scores
 
 
-AttributionScores = dict[str, float]
+EdgeAttributionScores = dict[EdgeName, float]
 
 
 def save_attribution_scores(
-    scores_dict: AttributionScores,
+    scores_dict: EdgeAttributionScores,
     savedir: str,
     filename: str = "attrib_scores",
 ):
@@ -193,7 +192,7 @@ def save_attribution_scores(
 def load_attribution_scores(
     savedir: str,
     filename: str = "attrib_scores",
-) -> AttributionScores:
+) -> EdgeAttributionScores:
     """Load the attribution scores from a pickle file."""
     obj = utils.load_obj_from_pickle(savedir, filename)
     assert isinstance(obj, dict), f"Expected dict, got {type(obj)}"

--- a/sae_eap/graph/__init__.py
+++ b/sae_eap/graph/__init__.py
@@ -1,3 +1,3 @@
-from .node import Node, TensorNode, SrcNode, DestNode
-from .edge import Edge, TensorEdge
+from .node import Node, TensorNode, AttentionNode
+from .edge import Edge, TensorEdge, EdgeName
 from .graph import Graph, TensorGraph

--- a/sae_eap/graph/edge.py
+++ b/sae_eap/graph/edge.py
@@ -1,14 +1,12 @@
 # from typing import Literal
 
 from dataclasses import dataclass
-from sae_eap.graph.node import Node, SrcNode, DestNode
+from sae_eap.graph.node import Node, TensorNode
 
 EdgeName = str
-# EdgeType = Literal["q", "k", "v", "na"]
-# # "q", "k", "v" correspond to the query, key, and value edges to a child attention node.
-# # "na" corresponds to an edge that does not have an attention node as a child.
 
 
+# TODO: replace with generic type
 @dataclass(eq=True, frozen=True)
 class Edge:
     """Base class to represent an edge in a graph."""
@@ -16,13 +14,8 @@ class Edge:
     parent: Node
     child: Node
 
-    @property
-    def name(self) -> str:
-        """The name of the edge."""
-        return f"{self.parent}->{self.child}"
-
     def __repr__(self):
-        return f"Edge({self.name})"
+        return f"Edge({self.parent}->{self.child})"
 
     """ Syntactic sugar """
 
@@ -34,18 +27,22 @@ class Edge:
     def dest(self) -> Node:
         return self.child
 
+    @property
+    def name(self) -> EdgeName:
+        return f"{self.parent.name}->{self.child.name}"
+
 
 @dataclass(eq=True, frozen=True)
 class TensorEdge(Edge):
     """An edge connecting two tensors in the model's computational graph."""
 
-    parent: SrcNode
-    child: DestNode
+    parent: TensorNode
+    child: TensorNode
 
     @property
-    def src(self) -> SrcNode:
+    def src(self) -> TensorNode:
         return self.parent
 
     @property
-    def dest(self) -> DestNode:
+    def dest(self) -> TensorNode:
         return self.child

--- a/sae_eap/graph/index.py
+++ b/sae_eap/graph/index.py
@@ -1,7 +1,7 @@
 # type: ignore
 from typing import Sequence
 from sae_eap.graph.graph import TensorGraph
-from sae_eap.graph.node import TensorNode, SrcNode, DestNode
+from sae_eap.graph.node import TensorNode
 
 # Unique index for each node in the graph.
 TensorNodeIndex = int
@@ -15,11 +15,13 @@ def build_node_index(nodes: Sequence[TensorNode]) -> dict[TensorNode, TensorNode
     return index
 
 
+# TODO: refactor into generic Indexer class that supports any hashable key.
+# TODO: instead of combining src and dest in a single index, have two separate indexers.
 class TensorGraphIndexer:
     """A class to index nodes in a graph."""
 
-    src_index: dict[SrcNode, TensorNodeIndex]
-    dest_index: dict[DestNode, TensorNodeIndex]
+    src_index: dict[TensorNode, TensorNodeIndex]
+    dest_index: dict[TensorNode, TensorNodeIndex]
 
     def __init__(self, graph: TensorGraph):
         self.build_index(graph)

--- a/sae_eap/prune.py
+++ b/sae_eap/prune.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import abc
 
 from sae_eap.graph.edge import TensorEdge
-from sae_eap.graph.node import SrcNode, DestNode, AttentionSrcNode
+from sae_eap.graph.node import TensorNode, AttentionNode
 from sae_eap.graph.build import build_attn_nodes, build_mlp_nodes
 from sae_eap.graph.graph import TensorGraph
-from sae_eap.attribute import AttributionScores
+from sae_eap.attribute import EdgeAttributionScores
 
 
 class Pruner(abc.ABC):
@@ -23,7 +23,7 @@ class Pruner(abc.ABC):
         return abs(score) if self.absolute else score
 
     @abc.abstractmethod
-    def prune(self, graph: TensorGraph, scores: AttributionScores):
+    def prune(self, graph: TensorGraph, scores: EdgeAttributionScores):
         raise NotImplementedError
 
 
@@ -41,7 +41,7 @@ class PruningPipeline(Pruner):
         self.pruners = []
         return self
 
-    def prune(self, graph: TensorGraph, scores: AttributionScores):
+    def prune(self, graph: TensorGraph, scores: EdgeAttributionScores):
         for pruner in self.pruners:
             pruner.prune(graph, scores)
 
@@ -54,7 +54,7 @@ class DeadNodePruner(Pruner):
     - The node is a destination node with no parents.
     """
 
-    def prune(self, graph: TensorGraph, scores: AttributionScores) -> None:
+    def prune(self, graph: TensorGraph, scores: EdgeAttributionScores) -> None:
         for node in graph.src_nodes:
             if len(graph.get_children(node)) == 0:
                 graph.remove_node(node)
@@ -71,7 +71,7 @@ class ThresholdEdgePruner(Pruner):
         super().__init__(absolute)
         self.threshold = threshold
 
-    def prune(self, graph: TensorGraph, scores: AttributionScores) -> None:
+    def prune(self, graph: TensorGraph, scores: EdgeAttributionScores) -> None:
         # Remove edges with score below threshold
         for edge in graph.edges:
             score = scores[edge.name]
@@ -87,7 +87,7 @@ class TopNEdgePruner(Pruner):
         super().__init__(absolute)
         self.n_edges = n_edges
 
-    def prune(self, graph: TensorGraph, scores: AttributionScores) -> None:
+    def prune(self, graph: TensorGraph, scores: EdgeAttributionScores) -> None:
         edges_sorted_by_score_descending = sorted(
             list(graph.edges),
             key=lambda edge: self.maybe_abs(scores[edge.name]),
@@ -101,13 +101,13 @@ class TopNEdgePruner(Pruner):
             graph.add_edge(edge)
 
 
-def get_dest_nodes_for_src_node(graph, src_node: SrcNode) -> list[DestNode]:
+def get_dest_nodes_for_src_node(graph, src_node: TensorNode) -> list[TensorNode]:
     if "mlp" in src_node.name:
         _, dest_node = build_mlp_nodes(graph)
         return [dest_node]
 
     elif "attn" in src_node.name:
-        assert isinstance(src_node, AttentionSrcNode)
+        assert isinstance(src_node, AttentionNode)
         _, dest_nodes = build_attn_nodes(graph, src_node.head_index)
         return dest_nodes  # type: ignore
 
@@ -116,11 +116,12 @@ def get_dest_nodes_for_src_node(graph, src_node: SrcNode) -> list[DestNode]:
 
 
 def get_incoming_edges_for_dest_node(
-    graph: TensorGraph, dest_node: DestNode
+    graph: TensorGraph, dest_node: TensorNode
 ) -> list[TensorEdge]:
     incoming_edges = []
+    assert dest_node.is_dest
     for parent in graph.get_parents(dest_node):
-        assert isinstance(parent, SrcNode)
+        assert parent.is_src
         edge = graph.edge_cls(parent, dest_node)
         incoming_edges.append(edge)
     return incoming_edges
@@ -133,7 +134,7 @@ class GreedyEdgePruner(Pruner):
         super().__init__(absolute)
         self.n_edges = n_edges
 
-    def prune(self, graph: TensorGraph, scores: AttributionScores) -> None:
+    def prune(self, graph: TensorGraph, scores: EdgeAttributionScores) -> None:
         # TODO: the implementation is a bit cursed
         raise NotImplementedError
 

--- a/sae_eap/runner.py
+++ b/sae_eap/runner.py
@@ -7,7 +7,7 @@ from sae_eap.graph import TensorGraph
 from sae_eap.graph.index import TensorGraphIndexer
 from sae_eap.data.handler import BatchHandler
 from sae_eap.attribute import (
-    AttributionScores,
+    EdgeAttributionScores,
     make_cache_hooks_and_dicts,
     compute_model_caches,
     compute_node_act_cache,
@@ -28,7 +28,7 @@ def run_attribution(
     *,
     aggregation="sum",
     quiet=False,
-) -> AttributionScores:
+) -> EdgeAttributionScores:
     if isinstance(iter_batch_handler, BatchHandler):
         iter_batch_handler = iter([iter_batch_handler])
 

--- a/tests/integration/runner/test_run_ablate.py
+++ b/tests/integration/runner/test_run_ablate.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sae_eap.core.types import Model
 from sae_eap.runner import run_ablation, run_attribution
 from sae_eap.graph.build import build_graph
@@ -16,7 +14,6 @@ def make_pruner():
     )
 
 
-@pytest.mark.xfail(reason="Needs a refactor of nodes")
 def test_run_ablation(ts_model: Model):
     graph = build_graph(ts_model.cfg)
     handler = make_single_prompt_handler(ts_model)

--- a/tests/unit/graph/test_graph.py
+++ b/tests/unit/graph/test_graph.py
@@ -7,12 +7,12 @@ from sae_eap.graph.edge import Edge
 
 @pytest.fixture
 def nodes():
-    return [Node("A"), Node("B"), Node("C")]
+    return [Node(name="A"), Node(name="B"), Node(name="C")]
 
 
 @pytest.fixture
 def edges():
-    return [Edge(Node("A"), Node("B")), Edge(Node("B"), Node("C"))]
+    return [Edge(Node(name="A"), Node(name="B")), Edge(Node(name="B"), Node(name="C"))]
 
 
 def test_graph_nodes(nodes, edges):

--- a/tests/unit/graph/test_node.py
+++ b/tests/unit/graph/test_node.py
@@ -2,5 +2,5 @@ from sae_eap.graph import Node
 
 
 def test_node_is_hashable():
-    node = Node("A")
+    node = Node(name="A")
     hash(node)


### PR DESCRIPTION
Unify SrcNode and DestNode, as in principle, a node can be both a SrcNode and a DestNode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed and restructured node classes to use `TensorNode` and `AttentionNode`.
  - Updated edge classes and methods for improved generic handling and performance.

- **Bug Fixes**
  - Corrected node and edge referencing in several modules to ensure proper functionality and type consistency.

- **Tests**
  - Updated unit tests to reflect changes in node instantiation and naming conventions.
  - Removed `@pytest.mark.xfail` from `test_run_ablation` to reevaluate test expectations.

- **Chores**
  - Removed unnecessary imports and cleaned up code for better maintainability and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->